### PR TITLE
Update k8s-prow images as needed

### DIFF
--- a/prow/cluster/01-config-generic.yaml
+++ b/prow/cluster/01-config-generic.yaml
@@ -51,10 +51,10 @@ data:
             path_strategy: explicit
           gcs_credentials_secret: gcs-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20221208-8898931a7f
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20221208-8898931a7f
-            initupload: gcr.io/k8s-prow/initupload:v20221208-8898931a7f
-            sidecar: gcr.io/k8s-prow/sidecar:v20221208-8898931a7f
+            clonerefs: gcr.io/k8s-prow/clonerefs:v20240513-660eb6de4
+            entrypoint: gcr.io/k8s-prow/entrypoint:v20240513-660eb6de4
+            initupload: gcr.io/k8s-prow/initupload:v20240513-660eb6de4
+            sidecar: gcr.io/k8s-prow/sidecar:v20240513-660eb6de4
 
     tide:
       queries:

--- a/prow/cluster/crier.yaml
+++ b/prow/cluster/crier.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/crier:v20240513-660eb6de4
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/deck.yaml
+++ b/prow/cluster/deck.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/deck:v20240513-660eb6de4
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/ghproxy:v20240513-660eb6de4
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/cluster/hook.yaml
+++ b/prow/cluster/hook.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/hook:v20240513-660eb6de4
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium.yaml
+++ b/prow/cluster/horologium.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/horologium:v20240513-660eb6de4
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/prow-controller-manager:v20240513-660eb6de4
         volumeMounts:
         - name: github-token
           mountPath: /etc/github

--- a/prow/cluster/sinker.yaml
+++ b/prow/cluster/sinker.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/sinker:v20240513-660eb6de4
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/statusreconciler.yaml
+++ b/prow/cluster/statusreconciler.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/status-reconciler:v20240513-660eb6de4
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/prow/cluster/tide.yaml
+++ b/prow/cluster/tide.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20221208-8898931a7f
+        image: gcr.io/k8s-prow/tide:v20240513-660eb6de4
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -57,10 +57,10 @@ plank:
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20221208-8898931a7f
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20221208-8898931a7f
-        initupload: gcr.io/k8s-prow/initupload:v20221208-8898931a7f
-        sidecar: gcr.io/k8s-prow/sidecar:v20221208-8898931a7f
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20240513-660eb6de4
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20240513-660eb6de4
+        initupload: gcr.io/k8s-prow/initupload:v20240513-660eb6de4
+        sidecar: gcr.io/k8s-prow/sidecar:v20240513-660eb6de4
 
 tide:
   queries:
@@ -1222,7 +1222,7 @@ presubmits:
     cluster: default
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1244,7 +1244,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1266,7 +1266,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1288,7 +1288,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1310,7 +1310,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1332,7 +1332,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1354,7 +1354,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1376,7 +1376,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:
@@ -1398,7 +1398,7 @@ presubmits:
         base_ref: main
     spec:
       containers:
-        - image: "gcr.io/k8s-prow/checkconfig:v20221208-8898931a7f"
+        - image: "gcr.io/k8s-prow/checkconfig:v20240513-660eb6de4"
           command:
             - "checkconfig"
           args:


### PR DESCRIPTION
Multiple distinct gcr.io/k8s-prow/ changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/chmrad/test-infra/compare/8898931a7f...660eb6de4 | 2022&#x2011;12&#x2011;08&nbsp;&#x2192;&nbsp;2024&#x2011;05&#x2011;13 | checkconfig, clonerefs, crier, deck, entrypoint, ghproxy, hook, horologium, initupload, prow-controller-manager, sidecar, sinker, status-reconciler, tide



Nobody is currently oncall, so falling back to Blunderbuss.

